### PR TITLE
Passed environment into apps script

### DIFF
--- a/apps-script/main/callable-functions.js
+++ b/apps-script/main/callable-functions.js
@@ -16,10 +16,11 @@
  * @return {string} the event id
  *
  */
-function createBooking(data) {
+function createBooking(data, environment) {
   console.log(data)
+  console.log(environment)
   var booking = JSON.parse(data)
-  var eventId = createEvent(booking)
+  var eventId = createEvent(booking, environment)
   if (booking.sendConfirmationEmail) {
     sendBookingConfirmationEmail(booking)
   }
@@ -33,11 +34,12 @@ function createBooking(data) {
  *
  * @param {object} data the booking object
  */
-function updateBooking(data) {
+function updateBooking(data, environment) {
   console.log(data)
+  console.log(environment)
   data = JSON.parse(data)
   const booking = data.booking
-  updateEvent(booking)
+  updateEvent(booking, environment)
   return
 }
 
@@ -48,8 +50,10 @@ function updateBooking(data) {
  *
  * @param {object} data the booking object
  */
-function deleteBooking(booking) {
-  deleteEvent(booking.eventId, booking.location)
+function deleteBooking(booking, environment) {
+  console.log(booking)
+  console.log(environment)
+  deleteEvent(booking.eventId, booking.location, environment)
 }
 
 /**

--- a/apps-script/main/events-crud.js
+++ b/apps-script/main/events-crud.js
@@ -3,7 +3,7 @@
  * 
  * @param {object} booking the booking object
  */
-function createEvent(booking) {
+function createEvent(booking, environment) {
 
   var eventName = `${booking.parentFirstName} / ${booking.childName} ${booking.childAge}th ${booking.parentMobile}`
   
@@ -11,7 +11,7 @@ function createEvent(booking) {
   var endDate = getEndDate(startDate, booking.partyLength)
   
   // determine which calendar to use
-  var calendarId = getCalendarId(booking.location)
+  var calendarId = getCalendarId(booking.location, environment)
 
   var newEvent = CalendarApp.getCalendarById(calendarId).createEvent(eventName, startDate, endDate)
   newEvent.setLocation(booking.address)
@@ -24,7 +24,7 @@ function createEvent(booking) {
  *
  * @param {object} booking the booking object
  */
-function updateEvent(booking) {
+function updateEvent(booking, environment) {
   
   var eventName = `${booking.parentFirstName} / ${booking.childName} ${booking.childAge}th ${booking.parentMobile}`
   
@@ -32,7 +32,7 @@ function updateEvent(booking) {
   var endDate = getEndDate(startDate, booking.partyLength)
   
   // determine which calendar to use
-  var calendarId = getCalendarId(booking.location)
+  var calendarId = getCalendarId(booking.location, environment)
                                     
   var event = CalendarApp.getCalendarById(calendarId).getEventById(booking.eventId)
   event.setTitle(eventName)
@@ -48,9 +48,9 @@ function updateEvent(booking) {
  * @param {string} eventId the id of the event to delete
  * @param {string} location the location of the booking
  */
-function deleteEvent(eventId, location) {
+function deleteEvent(eventId, location, environment) {
   
-  var calendarId = getCalendarId(location)
+  var calendarId = getCalendarId(location, environment)
   var event = CalendarApp.getCalendarById(calendarId).getEventById(eventId)
   event.deleteEvent()
 }

--- a/apps-script/main/utilities.js
+++ b/apps-script/main/utilities.js
@@ -117,13 +117,25 @@ function capitalise(string) {
  * 
  * @returns {String} the ID of the correct Calendar
  */
-function getCalendarId(location) {
+function getCalendarId(location, environment) {
 
   // event IDs
-  const balwynStorePartiesCalendarID = "fizzkidz.com.au_ofsgsp4oijbjpvm40o1bihk7bg@group.calendar.google.com"
-  const essendonStorePartiesClaendarID = "c_3aae8htcpjgpmnrod7ujrqsccc@group.calendar.google.com"
-  const malvernStorePartiesCalendarID = "fizzkidz.com.au_knove8gbjklh2cm5di6qfs0bs0@group.calendar.google.com"
-  const mobilePartiesCalendarID = "fizzkidz.com.au_k5gsanlpnslk9i4occfd4elt00@group.calendar.google.com"
+  var balwynStorePartiesCalendarID;
+  var essendonStorePartiesClaendarID;
+  var malvernStorePartiesCalendarID;
+  var mobilePartiesCalendarID;
+  
+  if (environment === "prod") {
+    balwynStorePartiesCalendarID = "fizzkidz.com.au_7vor3m1efd3fqbr0ola2jvglf8@group.calendar.google.com"
+    essendonStorePartiesClaendarID = "fizzkidz.com.au_k1ubc2bi0ufvhoer4o9pakion0@group.calendar.google.com"
+    malvernStorePartiesCalendarID = "fizzkidz.com.au_j13ot3jarb1p9k70c302249j4g@group.calendar.google.com"
+    mobilePartiesCalendarID = "fizzkidz.com.au_b9aruprq8740cdamu63frgm0ck@group.calendar.google.com"
+  } else {
+    balwynStorePartiesCalendarID = "fizzkidz.com.au_ofsgsp4oijbjpvm40o1bihk7bg@group.calendar.google.com"
+    essendonStorePartiesClaendarID = "c_3aae8htcpjgpmnrod7ujrqsccc@group.calendar.google.com"
+    malvernStorePartiesCalendarID = "fizzkidz.com.au_knove8gbjklh2cm5di6qfs0bs0@group.calendar.google.com"
+    mobilePartiesCalendarID = "fizzkidz.com.au_k5gsanlpnslk9i4occfd4elt00@group.calendar.google.com"
+  }
 
   switch (location) {
     case "balwyn":


### PR DESCRIPTION
This is a workaround for not having a separate development and production environment for apps-script... which isn't quite possible. Ideally apps-script should be ditched, but its heavily used for now.
This patch tells apps script if its dev or prod, and that can be used to determine which calendar to use, test calendars or prod calendars for managing bookings in Google Calendar.