### PR TITLE
Added price selection when sending an invoice

### DIFF
--- a/firebase/functions/src/acuity/stripe-integration.ts
+++ b/firebase/functions/src/acuity/stripe-integration.ts
@@ -19,6 +19,13 @@ function isAcuityError(object: any | Acuity.Error): object is Acuity.Error {
     return (object as Acuity.Error).error !== undefined
 }
 
+const pricesMap: { [key: string]: string } = {
+  '195': stripeConfig.STRIPE_PRICE_195,
+  '173': stripeConfig.STRIPE_PRICE_173,
+  '151': stripeConfig.STRIPE_PRICE_151,
+  '129': stripeConfig.STRIPE_PRICE_129
+}
+
 type RetrieveInvoiceParams = {
   appointmentId: number
 }
@@ -105,7 +112,12 @@ type SendInvoiceParams = {
   childName: string
   invoiceItem: string,
   appointmentTypeId: number,
+  price: string
   [key: string]: any
+}
+
+const SendInvoiceParamsValidator: SendInvoiceParams = {
+  email: '', name: '', phone: '', childName: '', invoiceItem: '', appointmentTypeId: 0, price: ''
 }
 
 type SendInvoiceResolve = (status: InvoiceStatusResponse) => void
@@ -124,7 +136,7 @@ export const sendInvoice = functions
       reject: SendInvoiceReject
     ) => {
 
-      for (const key in data) {
+      for (const key in SendInvoiceParamsValidator) {
         if (data[key] === undefined) {
           reject(new functions.https.HttpsError('invalid-argument', `${key} value not supplied`))
           return
@@ -176,7 +188,7 @@ function createInvoiceItem(
   const params: Stripe.InvoiceItemCreateParams = {
     customer: customer.id,
     description: data.invoiceItem,
-    price: stripeConfig.STRIPE_PRICE_SCIENCE_CLUB
+    price: pricesMap[data.price]
   }
 
   stripe.invoiceItems.create(params)

--- a/firebase/functions/src/constants/stripe/index.ts
+++ b/firebase/functions/src/constants/stripe/index.ts
@@ -1,14 +1,20 @@
 import * as stripeCredentials from '../../../credentials/stripe_credentials'
 
 export const DEV_CONFIG = {
-    STRIPE_PRICE_SCIENCE_CLUB: "price_1Gtj1JIhbh0YhdB7zAnYJwDN",
+    STRIPE_PRICE_195: "price_1IaZ4EIhbh0YhdB7jSoMwQ84",
+    STRIPE_PRICE_173: "price_1IaZnrIhbh0YhdB7wRhFqJLH",
+    STRIPE_PRICE_151: "price_1IaZo4Ihbh0YhdB7gFi5VJyp",
+    STRIPE_PRICE_129: "price_1IaZoIIhbh0YhdB7BE5QNu9h",
     SEND_INVOICE_ENDPOINT: "https://australia-southeast1-booking-system-6435d.cloudfunctions.net",
     STRIPE_DASHBOARD: "https://dashboard.stripe.com/test",
     API_KEY: stripeCredentials.api_keys.dev_api_key
 }
 
 export const PROD_CONFIG = {
-    STRIPE_PRICE_SCIENCE_CLUB: "term-2-2021",
+    STRIPE_PRICE_195: "term-2-2021",
+    STRIPE_PRICE_173: "price_1IaZl6Ihbh0YhdB785gfNjb8",
+    STRIPE_PRICE_151: "price_1IaZlNIhbh0YhdB70msuSsMo",
+    STRIPE_PRICE_129: "price_1IaZlcIhbh0YhdB77sWCAkar",
     SEND_INVOICE_ENDPOINT: "https://australia-southeast1-bookings-prod.cloudfunctions.net",
     STRIPE_DASHBOARD: "https://dashboard.stripe.com",
     API_KEY: stripeCredentials.api_keys.live_api_key

--- a/firebase/src/components/Dialogs/ConfirmationDialog/index.js
+++ b/firebase/src/components/Dialogs/ConfirmationDialog/index.js
@@ -5,12 +5,15 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles, FormControl, InputLabel, Select, MenuItem } from '@material-ui/core';
 
 const useStyles = makeStyles(theme => ({
     deleteButton: {
         color: 'red'
-    }    
+    },
+    form: {
+        width: '100%'
+    }
 }))
 
 /**
@@ -24,20 +27,37 @@ const withConfirmationDialog = Component => props => {
     const [open, setOpen] = useState(false)
     const [title, setTitle] = useState('')
     const [content, setContent] = useState('')
+    const [listItems, setListItems] = useState(null)
+    const [formError, setFormError] = useState(false)
+    const [selectedListItem, setSelectedListItem] = useState('')
     const [confirmButton, setConfirmButton] = useState('')
     const [confirmCallback, setConfirmCallback] = useState(null)
 
-    const handleShow = ({ title, message, confirmButton, onConfirm }) => {
+    const handleShow = ({ title, message, confirmButton, onConfirm, listItems }) => {
         setTitle(title)
         setContent(message)
         setConfirmButton(confirmButton)
         setConfirmCallback(() => onConfirm)
         setOpen(true)
+        listItems && setListItems(listItems)
+    }
+
+    const handleListItemChange = event => {
+        setSelectedListItem(event.target.value)
+        setFormError(false)
     }
 
     const handleConfirm = () => {
-        confirmCallback()
-        setOpen(false)
+        if (listItems && !selectedListItem) {
+            setFormError(true)
+        } else {
+            if (listItems) {
+                confirmCallback(selectedListItem)
+            } else {
+                confirmCallback()
+            }
+            setOpen(false)
+        }
     }
 
     const handleClose = () => {
@@ -53,6 +73,14 @@ const withConfirmationDialog = Component => props => {
                 <DialogTitle >{title}</DialogTitle>
                 <DialogContent>
                     <DialogContentText>{content}</DialogContentText>
+                    {listItems && 
+                            <FormControl className={classes.form} error={formError}>
+                                <InputLabel>{listItems.title}</InputLabel>
+                                <Select value={selectedListItem} onChange={handleListItemChange}>
+                                    {listItems.items.map(item => <MenuItem key={item.key} value={item.key}>{item.value}</MenuItem>)}
+                                </Select>
+                            </FormControl>
+                    }
                 </DialogContent>
                 <DialogActions>
                     <Button onClick={handleConfirm} classes={{ root: classes.deleteButton }}>


### PR DESCRIPTION
Added a `listItems` prop into the `ConfirmationDialog` which, when provided, will show a list of the items along with the title. If this prop is provided, the `onConfirm()` callback will also provide the value of the selected list item.
This extended confirmation dialog was used to show different prices available for selection when sending an invoice.
Also fixed validation of params when sending an invoice - this was broken and previously no appointmentTypeID was being provided, and all classes of the client were being updated, including previous terms.