### PR TITLE
Replaced `moment` with `luxon`

### DIFF
--- a/firebase/package-lock.json
+++ b/firebase/package-lock.json
@@ -8762,6 +8762,11 @@
         "yallist": "^3.0.2"
       }
     },
+    "luxon": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
+      "integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A=="
+    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -9141,9 +9146,9 @@
       }
     },
     "moment": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "moment-timezone": {
       "version": "0.5.31",

--- a/firebase/package.json
+++ b/firebase/package.json
@@ -14,7 +14,7 @@
     "firebase": "^7.15.3",
     "fizz-kidz": "file:functions/shared",
     "googleapis": "^39.2.0",
-    "moment": "^2.26.0",
+    "luxon": "^1.26.0",
     "moment-timezone": "^0.5.28",
     "query-string": "^6.8.3",
     "react": "^16.10.2",

--- a/firebase/src/components/HolidayPrograms/SelectClass/index.js
+++ b/firebase/src/components/HolidayPrograms/SelectClass/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
-import moment from 'moment'
+import { DateTime } from 'luxon'
 
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
@@ -198,11 +198,11 @@ const HolidayProgramSelection = props => {
                         disabled={classes.length === 0}
                     >
                         {classes.map(mClass => {
-                            const yesterday = new Date()
-                            yesterday.setDate(yesterday.getDate() - 1)
-                            if (new Date(mClass.time) > yesterday) {
+                            const yesterday = DateTime.now().minus({ days: 1 })
+                            const classDateTime = DateTime.fromISO(mClass.time)
+                            if (classDateTime > yesterday) {
                                 return <MenuItem key={mClass.id} value={mClass}>
-                                {moment(mClass.time).format('dddd, MMMM Do h:mm A, YYYY')}
+                                {classDateTime.toFormat('EEEE MMMM d, h:mm a, yyyy')}
                             </MenuItem>
                             }
                         })}

--- a/firebase/src/components/Shared/ScienceClubClassSelection.js
+++ b/firebase/src/components/Shared/ScienceClubClassSelection.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react'
-import moment from 'moment'
+import { DateTime } from 'luxon'
 
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
@@ -187,7 +187,7 @@ const ScienceClubClassSelection = props => {
                         >
                             {classes.map(mClass => (
                                 <MenuItem key={mClass.id} value={mClass}>
-                                    {moment(mClass.time).format('dddd, MMMM Do, YYYY')}
+                                    {DateTime.fromISO(mClass.time).toFormat('EEEE MMMM d, h:mm a, yyyy')}
                                 </MenuItem>
                             ))}
                         </Select>


### PR DESCRIPTION
This was because the iPads in the stores, along with their older versions of Safari, could not properly pass `moment` dates. Luxon resolves this.
Also used luxon to compare dates, which seems to be more stable.