### PR TITLE
Moved environment variable injection immediately before react-scripts

### DIFF
--- a/firebase/package.json
+++ b/firebase/package.json
@@ -31,9 +31,9 @@
   },
   "scripts": {
     "build-fizz-kidz": "npm --prefix functions/fizz-kidz run build",
-    "start": "REACT_APP_ENV=dev npm run build-fizz-kidz && react-scripts start",
-    "build-prod": "REACT_APP_ENV=prod npm run build-fizz-kidz && react-scripts build",
-    "build-dev": "REACT_APP_ENV=dev npm run build-fizz-kidz && react-scripts build",
+    "start": "npm run build-fizz-kidz && REACT_APP_ENV=dev react-scripts start",
+    "build-prod": "npm run build-fizz-kidz && REACT_APP_ENV=prod react-scripts build",
+    "build-dev": "npm run build-fizz-kidz && REACT_APP_ENV=dev react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Before it was not actually being injected, and always defaulting to dev since I was using a ternary. Only able to be picked up in production... where it was! 🤦‍♂️