### PR TITLE
Fixed formatting of dateTime for science club backup

### DIFF
--- a/apps-script/main/callable-functions.js
+++ b/apps-script/main/callable-functions.js
@@ -175,7 +175,7 @@ function backupScienceClub(appointmentsMap) {
         appointment.label,
         appointment.notes,
         appointment.checkoutPerson,
-        appointment.checkoutTime
+        appointment.checkoutTime ? Utilities.formatDate(new Date(appointment.checkoutTime), 'Australia/Melbourne', 'h:m a') : ''
       ])
     })
   }

--- a/firebase/functions/src/acuity/science-club-backup.ts
+++ b/firebase/functions/src/acuity/science-club-backup.ts
@@ -140,7 +140,7 @@ async function mergeCheckoutData(appointment: Acuity.MergedAppointment) {
     const doc = await firestore.collection('scienceClubAppointments').doc(appointment.id.toString()).get()
     if (doc.exists) {
         appointment.checkoutPerson = doc.data()?.pickupPerson
-        appointment.checkoutTime = doc.data()?.timeStamp
+        appointment.checkoutTime = doc.data()?.timeStamp.toDate()
         return appointment
     }
     return appointment


### PR DESCRIPTION
Previously a firestore TimeStamp was being passed around (object with seconds and nanoseconds..)
Ensured its now sent as an ISO date string then converted and formatted for the spreadsheet.