### PR TITLE
Check that form hasn't been filled in previously

### DIFF
--- a/apps-script/main/feedback_email_template.html
+++ b/apps-script/main/feedback_email_template.html
@@ -9,8 +9,10 @@
         <p>As we are a growing business we would thoroughly appreciate it if you could write a review about your Fizz Kidz experience by 
             <? if (location === 'balwyn') { ?>
                 <a href="https://search.google.com/local/writereview?placeid=ChIJRYl9pexB1moR5msbM8SdKVU">clicking on this link.</a>
-            <? } else { ?>
+            <? } else if (location === 'essendon') { ?>
                 <a href="https://search.google.com/local/writereview?placeid=ChIJq_RqJMNd1moRksRMHNY2ExQ">clicking on this link.</a>
+            <? } else { ?>
+                <a href="https://search.google.com/local/writereview?placeid=ChIJ92NJJx5q1moRdDSJo_X3BRo">clicking on this link.</a>
             <? } ?>
         </p>
         <p>It will just take 10 seconds, we promise :)</p>

--- a/firebase/functions/src/bookings/onFormSubmit.ts
+++ b/firebase/functions/src/bookings/onFormSubmit.ts
@@ -60,17 +60,25 @@ export const onFormSubmit = functions
                             functions.logger.log("booking updated successfully")
                             functions.logger.log("updated booking:")
                             functions.logger.log(updatedBooking)
-                            functions.logger.log(`calling apps script ${AppsScript.Functions.ON_FORM_SUBMIT_BOOKING_FOUND}`)
-                            runAppsScript(AppsScript.Functions.ON_FORM_SUBMIT_BOOKING_FOUND, [updatedBooking, creations, additions])
-                                .then(_ => {
-                                        functions.logger.log(`${AppsScript.Functions.ON_FORM_SUBMIT_BOOKING_FOUND} finished successfully`)
-                                        res.status(200).send()
-                                })
-                                .catch(err => {
-                                    functions.logger.error(`error running ${AppsScript.Functions.ON_FORM_SUBMIT_BOOKING_FOUND}`)
-                                    functions.logger.error(err)
-                                    res.status(500).send(err)
-                                })
+
+                            // only trigger confirmation emails (apps script booking found) if its the first time the form has been filled out
+                            // decide this based on creation1. if creations were null previously, this must be the first time filling in the form
+                            if (!booking.creation1) {
+                                functions.logger.log(`calling apps script ${AppsScript.Functions.ON_FORM_SUBMIT_BOOKING_FOUND}`)
+                                runAppsScript(AppsScript.Functions.ON_FORM_SUBMIT_BOOKING_FOUND, [updatedBooking, creations, additions])
+                                    .then(_ => {
+                                            functions.logger.log(`${AppsScript.Functions.ON_FORM_SUBMIT_BOOKING_FOUND} finished successfully`)
+                                            res.status(200).send()
+                                    })
+                                    .catch(err => {
+                                        functions.logger.error(`error running ${AppsScript.Functions.ON_FORM_SUBMIT_BOOKING_FOUND}`)
+                                        functions.logger.error(err)
+                                        res.status(500).send(err)
+                                    })
+                            } else {
+                                functions.logger.log("form filled out previously, no need to send confirmation emails")
+                                res.status(200).send()
+                            }
                         })
                         .catch(err => {
                             functions.logger.error("error updating booking")


### PR DESCRIPTION
Due to issues where iPhones can resubmit forms when re-opening safari, a form can be resubmitted hours later, and a parent gets a confirmation email again.
This patch adds a check that the creation1 value has not been set before, and if so, sends the emails. Otherwise, it will just update the booking but no need to notify anyone of anything.

Also added malvern back into feedback emails.