### PR TITLE
fixed auth to sync properly

### DIFF
--- a/firebase/src/components/App/index.tsx
+++ b/firebase/src/components/App/index.tsx
@@ -52,49 +52,49 @@ const App = () => {
             path: ROUTES.SCIENCE_CLUB_SELECT_CLASS,
             lazy: async () => {
                 const { ScienceClubCheckinClassSelection } = await import('../ScienceClub/Checkin/SelectClass')
-                return { Component: withAuthorization([Role.BASIC], ScienceClubCheckinClassSelection) }
+                return { Component: withAuthorization(['BASIC'], ScienceClubCheckinClassSelection) }
             },
         },
         {
             path: ROUTES.SCIENCE_CLUB_CLASS_DETAILS,
             lazy: async () => {
                 const { ScienceClubCheckinClassDetails } = await import('../ScienceClub/Checkin/ClassDetails')
-                return { Component: withAuthorization([Role.BASIC], ScienceClubCheckinClassDetails) }
+                return { Component: withAuthorization(['BASIC'], ScienceClubCheckinClassDetails) }
             },
         },
         {
             path: ROUTES.SCIENCE_CLUB_INVOICING_SELECT_CLASS,
             lazy: async () => {
                 const { ScienceClubInvoicingClassSelection } = await import('../ScienceClub/Invoicing/SelectClass')
-                return { Component: withAuthorization([Role.ADMIN], ScienceClubInvoicingClassSelection) }
+                return { Component: withAuthorization(['ADMIN'], ScienceClubInvoicingClassSelection) }
             },
         },
         {
             path: ROUTES.SCIENCE_CLUB_INVOICING_STATUS,
             lazy: async () => {
                 const { ScienceClassDashboard } = await import('../ScienceClub/Invoicing/InvoiceStatusPage')
-                return { Component: withAuthorization([Role.ADMIN], ScienceClassDashboard) }
+                return { Component: withAuthorization(['ADMIN'], ScienceClassDashboard) }
             },
         },
         {
             path: ROUTES.HOLIDAY_PROGRAM_SELECT_CLASS,
             lazy: async () => {
                 const { HolidayProgramSelection } = await import('../HolidayPrograms/SelectClass')
-                return { Component: withAuthorization([Role.BASIC], HolidayProgramSelection) }
+                return { Component: withAuthorization(['BASIC'], HolidayProgramSelection) }
             },
         },
         {
             path: ROUTES.HOLIDAY_PROGRAM_CLASS_DETAILS,
             lazy: async () => {
                 const { ClassDetailsPage } = await import('../HolidayPrograms/ClassDetails')
-                return { Component: withAuthorization([Role.BASIC], ClassDetailsPage) }
+                return { Component: withAuthorization(['BASIC'], ClassDetailsPage) }
             },
         },
         {
             path: ROUTES.BOOKINGS,
             lazy: async () => {
                 const { BookingsPage } = await import('../Bookings')
-                return { Component: withAuthorization([Role.BASIC, Role.RESTRICTED], BookingsPage) }
+                return { Component: withAuthorization(['BASIC', 'RESTRICTED'], BookingsPage) }
             },
         },
         {
@@ -138,7 +138,7 @@ const App = () => {
             path: ROUTES.PAYROLL,
             lazy: async () => {
                 const { Payroll } = await import('../Payroll/Payroll')
-                return { Component: withAuthorization([Role.BOOKKEEPER], Payroll) }
+                return { Component: withAuthorization(['BOOKKEEPER'], Payroll) }
             },
         },
     ])

--- a/firebase/src/components/Hooks/UseScopes.ts
+++ b/firebase/src/components/Hooks/UseScopes.ts
@@ -1,4 +1,3 @@
-import { Role } from '../../constants/roles'
 import { Scope } from '../../constants/scopes'
 import { useAuth } from './context/useAuth'
 
@@ -7,18 +6,20 @@ type Permission = 'read' | 'write' | 'restricted' | 'none'
 export function useScopes(): { [key in Scope]: Permission } {
     const authUser = useAuth()
 
-    const role = authUser?.role ?? Role.NONE
+    const role = authUser?.role
+
+    if (!role) {
+        return { [Scope.CORE]: 'none', [Scope.PAYROLL]: 'none' }
+    }
 
     switch (role) {
-        case Role.ADMIN:
+        case 'ADMIN':
             return { [Scope.CORE]: 'write', [Scope.PAYROLL]: 'write' }
-        case Role.BASIC:
+        case 'BASIC':
             return { [Scope.CORE]: 'read', [Scope.PAYROLL]: 'none' }
-        case Role.BOOKKEEPER:
+        case 'BOOKKEEPER':
             return { [Scope.CORE]: 'none', [Scope.PAYROLL]: 'write' }
-        case Role.RESTRICTED:
+        case 'RESTRICTED':
             return { [Scope.CORE]: 'restricted', [Scope.PAYROLL]: 'none' }
-        case Role.NONE:
-            return { [Scope.CORE]: 'none', [Scope.PAYROLL]: 'none' }
     }
 }

--- a/firebase/src/components/Session/Unauthorised.tsx
+++ b/firebase/src/components/Session/Unauthorised.tsx
@@ -3,13 +3,21 @@ import React from 'react'
 import * as Logo from '../../drawables/FizzKidzLogoHorizontal.png'
 import { useNavigate } from 'react-router-dom'
 import * as ROUTES from '../../constants/routes'
+import useFirebase from '../Hooks/context/UseFirebase'
 
 const { Header, Content } = Layout
 
-type Props = {}
+type Props = {
+    showLogout?: boolean
+}
 
-const Unauthorised: React.FC<Props> = () => {
+const Unauthorised: React.FC<Props> = ({ showLogout = false }) => {
+    const firebase = useFirebase()
     const navigate = useNavigate()
+
+    const goHome = () => navigate(ROUTES.LANDING)
+    const signOut = () => firebase.doSignOut()
+
     return (
         <Layout style={{ background: 'rgb(240, 242, 245)', height: '100vh' }}>
             <Header style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -26,8 +34,8 @@ const Unauthorised: React.FC<Props> = () => {
                     title="Unauthorised"
                     subTitle="Sorry, you are not authorised to access this page."
                     extra={
-                        <Button type="primary" onClick={() => navigate(ROUTES.LANDING)}>
-                            Back Home
+                        <Button type="primary" onClick={showLogout ? signOut : goHome}>
+                            {showLogout ? 'Logout' : 'Back Home'}
                         </Button>
                     }
                 />

--- a/firebase/src/components/Session/withAuthentication.js
+++ b/firebase/src/components/Session/withAuthentication.js
@@ -30,6 +30,8 @@ const withAuthentication = (Component) => {
                                 }
 
                                 this.setState({ authUser })
+                            } else {
+                                this.setState({ authUser: { uid: authUser.uid, email: authUser.email } })
                             }
                         })
                 } else {

--- a/firebase/src/components/Session/withAuthorization.tsx
+++ b/firebase/src/components/Session/withAuthorization.tsx
@@ -4,12 +4,14 @@ import { useNavigate } from 'react-router-dom'
 import * as ROUTES from '../../constants/routes'
 import * as LogoGif from '../../drawables/fizz_logo.gif'
 import useFirebase from '../Hooks/context/UseFirebase'
-import { Role } from '../../constants/roles'
+import { ROLES, Role } from '../../constants/roles'
 import { useAuth } from '../Hooks/context/useAuth'
 import Unauthorised from './Unauthorised'
 
 /**
- * Wraps a component with authorised roles, to ensure only correct users see the content.
+ * Wraps component with authorised roles, to ensure only correct users see the content.
+ * Wrapped components will show the Fizzing logo until authentication has settled.
+ * Once settled, unauthorised users will be taken back to sign-in.
  *
  * @param roles an array of roles allow to view this page. An empty array means any authenticated user can view this page.
  * No need to provide Role.ADMIN, as admins can view everything.
@@ -32,8 +34,13 @@ const withAuthorization = (roles: Role[], Component: React.FunctionComponent) =>
         })
 
         if (authUser) {
-            // admin is allowed to view all pages
-            if (authUser.role === Role.ADMIN) return <Component />
+            if (!authUser.role || !ROLES.includes(authUser.role)) {
+                return <Unauthorised showLogout />
+            }
+
+            if (authUser.role === 'ADMIN')
+                // admin is allowed to view all pages
+                return <Component />
 
             // empty roles means any authenticated user can view it
             if (roles.length === 0) {

--- a/firebase/src/components/SignIn/SignInGoogle.js
+++ b/firebase/src/components/SignIn/SignInGoogle.js
@@ -41,12 +41,8 @@ const SignInGoogle = (props) => {
     const handleSubmit = (event) => {
         firebase
             .doSignInWithGoogle()
-            .then((socialAuthUser) => {
+            .then(() => {
                 setError(null)
-                firebase.db
-                    .collection('users')
-                    .doc(socialAuthUser.user.uid)
-                    .set({ email: socialAuthUser.user.email }, { merge: true })
                 navigate(ROUTES.LANDING)
             })
             .catch((error) => {

--- a/firebase/src/components/SignIn/index.js
+++ b/firebase/src/components/SignIn/index.js
@@ -72,8 +72,7 @@ const SignInPage = () => {
 
         firebase
             .doSignInWithEmailAndPassword(email, password)
-            .then((authUser) => {
-                firebase.db.collection('users').doc(authUser.user.uid).set({ username: email }, { merge: true })
+            .then(() => {
                 setLoading(false)
                 navigate(ROUTES.LANDING)
             })

--- a/firebase/src/constants/roles.ts
+++ b/firebase/src/constants/roles.ts
@@ -1,12 +1,3 @@
-export enum Role {
-    // can do anything
-    ADMIN = 'ADMIN',
-    // read permissions on everything
-    BASIC = 'BASIC',
-    // can access bookings as read only, with information limited
-    RESTRICTED = 'RESTRICTED',
-    // can only access payroll
-    BOOKKEEPER = 'BOOKKEEPER',
-    // fallback for if user has no role
-    NONE = 'NONE',
-}
+export const ROLES = ['ADMIN', 'BASIC', 'RESTRICTED', 'BOOKKEEPER'] as const
+
+export type Role = (typeof ROLES)[number]


### PR DESCRIPTION
updating firestore with user details after login was causing confusing double snapshots, and not always with the data from the database. now, just being authenticated isn't enough, but you need a valid role on your database account