### PR TITLE
Add detailed READMEs for client, server, and fizz-kidz module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,106 @@
+# Fizz Kidz Portal
+
+The Fizz Kidz Portal is an internal management system streamlining Fizz Kidz operations. It integrates third-party services and uses Firebase for backend functionality, including role-based authentication via Firebase Auth.
+
+**Key Integrations:**
+
+*   **Scheduling:** Acuity Scheduling (for holiday programs, after-school programs, play lab)
+*   **Payments:** Square
+*   **Analytics:** Mixpanel
+*   **Email:** SendGrid (using MJML for templating)
+*   **CRM:** Zoho
+*   **CMS:** Storyblok
+*   **Payroll:** Xero
+*   **Rostering:** Sling
+
+## Table of Contents
+
+*   [Client](#client)
+*   [Server](#server)
+*   [tRPC Interaction](#trpc-interaction)
+
+## Client
+
+The client-side application handles the user interface and interaction.
+
+*   **Framework:** [React](https://react.dev/).
+*   **Build Tool:** [Vite](https://vitejs.dev/) for fast development and optimized builds (see `client/vite.config.ts`).
+*   **Routing:** [React Router DOM](https://reactrouter.com/) for client-side routing (see `client/src/app.tsx`).
+*   **API Consumption:** Uses [tRPC](https://trpc.io/) to communicate with the server.
+    *   tRPC client initialized in `client/src/utilities/trpc.ts`.
+    *   Enables type-safe API calls from React components (see `client/src/app.tsx` and its children).
+
+## Server
+
+The server-side application handles business logic, data processing, and API provision using [Node.js](https://nodejs.org/) and [TypeScript](https://www.typescriptlang.org/).
+
+*   **Main Entry:** `server/src/index.ts` exports modules for various application features (e.g., acuity, events, party bookings).
+*   **Core Logic:** Shared business logic, types, and utilities reside in `server/fizz-kidz/src/index.ts`.
+*   **API with tRPC:**
+    *   Exposes a tRPC API for client consumption.
+    *   Comprises multiple feature-specific routers (e.g., `partiesRouter`, `eventsRouter`) consolidated into `appRouter` (`server/src/trpc/trpc.app-router.ts`), which defines the full API.
+    *   `server/src/trpc/trpc.adapter.ts`'s `onRequestTrpc` function exposes each tRPC router (e.g., `partiesRouter`) as an individual [Firebase Function](https://firebase.google.com/docs/functions). Each main route group in `trpc.app-router.ts` maps to a separate serverless function.
+
+## tRPC Interaction
+
+[tRPC](https://trpc.io/) enables type-safe client-server communication. By sharing TypeScript types directly (via `AppRouter` from `server/src/trpc/trpc.app-router.ts` imported into `client/src/utilities/trpc.ts`), the client calls server procedures with full type-checking and autocompletion. This boosts developer experience and cuts integration errors, eliminating manual schema sync or code generation.
+
+## Project Structure
+
+A monorepo co-locating client and server:
+
+*   **`client/`**: React frontend.
+*   **`server/`**: Node.js backend (tRPC API definitions, Firebase Functions).
+*   **`server/fizz-kidz/`**: Shared core logic, types, and utilities. Located in `server/` for Firebase Functions compatibility, ensuring it's packaged as a local dependency for server deployment. Built separately, used by server and client build processes.
+
+## Setup and Installation
+
+1.  **Clone repo.**
+2.  **Install server dependencies:** `cd server && npm install && cd ..`
+3.  **Install client dependencies:** `cd client && npm install && cd ..`
+    *Note: Client builds depend on `../server/fizz-kidz`. Ensure its dependencies are installed.*
+
+## Development
+
+**Client:**
+
+Start the client dev server (hot reloading): `cd client && npm start`
+*   This builds `server/fizz-kidz` (watch), runs TS checker (watch), and starts Vite dev server (e.g., `localhost:5173`).
+
+Other client scripts (`client/package.json`):
+*   `build:dev`: Development build.
+*   `build:prod`: Production build (to `client/dist`).
+*   `lint`: Lint client code.
+*   `ts:check`: Check types with TypeScript compiler.
+
+**Server:**
+
+Run server locally with Firebase emulators: `cd server && npm run serve`
+*   This builds server code (incl. `fizz-kidz`) (watch) and starts Firebase emulators (Functions, Pub/Sub) for local testing.
+
+Other server scripts (`server/package.json`):
+*   `build`: Production build of server functions (to `server/lib`).
+*   `lint`: Lint server code.
+*   `logs`: Fetch Firebase functions logs.
+*   `test`: Run server-side tests (requires `fizz-kidz` build).
+
+## Deployment
+
+Deployed using Firebase.
+
+*   **Client (Firebase Hosting):**
+    *   Client app built to static assets (`client/dist/`).
+    *   Served by Firebase Hosting.
+    *   `firebase.json` defines hosting config (URL rewrites, `predeploy` script: `sh ./client/predeploy.sh`).
+*   **Server (Firebase Functions):**
+    *   tRPC API deployed as multiple Firebase Functions. Each router in `server/src/trpc/trpc.app-router.ts` (e.g., `partiesRouter`) is a distinct function.
+    *   Client dynamically routes tRPC requests to the correct Firebase Function URL (see `client/src/components/root/root.tsx` for tRPC client `fetch` logic).
+    *   `firebase.json` specifies `server/` as functions source.
+    *   `functions` `predeploy` script in `firebase.json` (`npm --prefix "$RESOURCE_DIR" run build`) builds server code.
+    *   Deploy via Firebase CLI:
+        ```bash
+        cd server && npm run deploy
+        # Or from root: firebase deploy --only functions
+        ```
+
+See `firebase.json`, `client/package.json`, `server/package.json` for detailed configurations.

--- a/client/README.md
+++ b/client/README.md
@@ -1,70 +1,69 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+# Fizz Kidz Portal - Client Application
 
-## Available Scripts
+This directory contains the frontend React application for the Fizz Kidz Portal.
 
-In the project directory, you can run:
+## Table of Contents
 
-### `npm start`
+- [Key Technologies](#key-technologies)
+- [Project Structure](#project-structure)
+- [Routing](#routing)
+- [UI Components](#ui-components)
+- [State Management](#state-management)
+- [API Communication](#api-communication)
+- [Development](#development)
 
-Runs the app in the development mode.<br>
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+## Key Technologies
 
-The page will reload if you make edits.<br>
-You will also see any lint errors in the console.
+- **Framework:** React
+- **Build Tool:** Vite
+- **Routing:** React Router DOM
+- **UI:** shadcn/ui (with Tailwind CSS & Radix UI). Material UI (MUI) and Ant Design are present but are being phased out.
+- **State Management:** Zustand (preferred), React Context
+- **API:** tRPC client
 
-### `npm test`
+## Project Structure
 
-Launches the test runner in the interactive watch mode.<br>
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+The client-side code is organized within `client/src/`:
 
-### `npm run build`
+-   **`app.tsx`**: Entry point for routing configuration.
+-   **`components/`**: Contains all React components, further organized by feature (e.g., `Bookings/`, `HolidayPrograms/`) or shared functionality (e.g., `Shared/`, `Session/`).
+    -   **`components/root/root.tsx`**: The root component of the application. It wraps all page content and is responsible for setting up global context providers, including the tRPC client, authentication, theming, and more.
+-   **`ui-components/`**: Likely contains `shadcn/ui` components.
+-   **`utilities/`**: Helper functions and utilities.
+-   **`hooks/`**: Custom React hooks.
+-   **`assets/` or `drawables/`**: Static assets like images and fonts.
 
-Builds the app for production to the `build` folder.<br>
-It correctly bundles React in production mode and optimizes the build for the best performance.
+## Routing
 
-The build is minified and the filenames include the hashes.<br>
-Your app is ready to be deployed!
+-   **React Router DOM:** Routing is handled using `react-router-dom`, with routes defined in `client/src/app.tsx` using `createBrowserRouter`.
+-   **Root Layout:** The `client/src/components/root/root.tsx` component serves as the primary layout shell, providing essential contexts (like tRPC, Auth, Theming) to all routes via the `<Outlet />` mechanism.
+-   **Dashboard vs. Public Routes:** The application has a clear distinction between:
+    -   **Dashboard Routes:** Primarily under the `/dashboard` path, often utilizing `DashboardLayout` and `ProtectedRoute` for authenticated staff access.
+    -   **Public Routes:** Accessible to all users, such as sign-in/sign-up pages, program enrolment forms (e.g., `/after-school-program-enrolment-form`), customer booking screens, and invitation views.
+-   **Lazy Loading:** All page components are lazy-loaded in `app.tsx` (using `React.lazy` and `Suspense`). This is a key optimization strategy for this Single Page Application (SPA), ensuring that users only download the code necessary for the parts of the portal they are interacting with, improving initial load times.
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+## UI Components
 
-### `npm run eject`
+-   **`shadcn/ui`:** This is the current preferred UI component library, built upon Tailwind CSS and Radix UI. Components are typically added to the `ui-components/ui/` directory.
+-   **Legacy Libraries:** Material UI (MUI) and Ant Design components are also present in the codebase but are being progressively phased out in favor of `shadcn/ui`.
 
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+## State Management
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+-   **Zustand:** Zustand is the preferred global state management solution for more complex state needs.
+-   **React Context:** React's built-in Context API is also utilized, particularly for managing global concerns like authentication state (`components/Session/auth-provider.tsx`) and organization selection (`components/Session/org-provider.tsx`), often within the `Root` component's providers.
 
-Instead, it will copy all the configuration files and the transitive dependencies (Webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+## API Communication
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+-   The client communicates with the backend server via tRPC.
+-   The tRPC client is configured in `client/src/components/root/root.tsx` and made available to the component tree through a React Context provider. This setup enables type-safe API calls from anywhere in the application.
+-   The client-side tRPC setup includes logic to dynamically route requests to the correct individual Firebase Function on the server based on the tRPC procedure path.
 
-## Learn More
+## Development
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+To run the client application in development mode:
 
-To learn React, check out the [React documentation](https://reactjs.org/).
+```bash
+npm start
+```
 
-### Code Splitting
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
-
-### Analyzing the Bundle Size
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
-
-### Making a Progressive Web App
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
-
-### Advanced Configuration
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
-
-### Deployment
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
-
-### `npm run build` fails to minify
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify
-
-© Ryan Saffer 2019
+This command (as defined in `client/package.json`) typically builds the shared `fizz-kidz` module (from `../server/fizz-kidz`), runs the TypeScript checker, and starts the Vite development server with hot reloading.

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,90 @@
+# Fizz Kidz Portal - Server Application
+
+This directory contains the backend Node.js application for the Fizz Kidz Portal, built with TypeScript and deployed primarily on Firebase Functions.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Core Technologies](#core-technologies)
+- [Project Structure](#project-structure)
+- [Function Types](#function-types)
+  - [tRPC Routers](#trpc-routers)
+  - [Webhook Handlers](#webhook-handlers)
+  - [Pub/Sub Functions](#pubsub-functions)
+- [Key Design Patterns](#key-design-patterns)
+  - [Lazy Instantiation of SDK Clients](#lazy-instantiation-of-sdk-clients)
+- [Development](#development)
+
+## Overview
+
+The server provides the API for the client application and handles background tasks, integrations with third-party services, and business logic execution. It leverages a serverless architecture using Firebase Functions to ensure scalability and manage costs.
+
+## Core Technologies
+
+- **Runtime:** Node.js
+- **Language:** TypeScript
+- **Deployment:** Firebase Functions
+- **API:** tRPC
+- **Database:** Firebase Firestore (implicitly, via `fizz-kidz` module and Firebase Admin SDK usage)
+- **Messaging:** Google Cloud Pub/Sub
+
+## Project Structure
+
+Key directories within `server/src/`:
+
+-   **`index.ts`**: Main entry point that exports all deployable Firebase Functions.
+-   **`fizz-kidz/`**: A crucial local module containing shared core business logic, types, and utilities. (See `server/fizz-kidz/README.md` for more details).
+-   **`trpc/`**: Contains tRPC configuration, the main `appRouter` (primarily for type generation), and the `trpc.adapter.ts` used to wrap tRPC routers into Firebase Functions.
+-   **Feature-Specific Directories (e.g., `acuity/`, `party-bookings/`, `stripe/`, `staff/`):** Each directory typically encapsulates logic related to a specific domain or feature.
+    -   `core/`: Often contains the main business logic.
+    -   `functions/`: Contains the actual Firebase Function handlers (tRPC, webhooks, Pub/Sub).
+    -   `index.ts` (within each feature directory): Exports the functions to be included in the main `server/src/index.ts`.
+-   **`firebase/`**: Utilities for interacting with Firebase services (Firestore, Pub/Sub, Storage).
+-   **`utilities/`**: General helper functions.
+
+## Function Types
+
+All functions exported from `server/src/index.ts` are deployed as individual Firebase Functions. They primarily fall into these categories:
+
+### tRPC Routers
+
+-   Most of the API is built using tRPC.
+-   Each feature-specific tRPC router (e.g., `partiesRouter` in `party-bookings/`, `authRouter` in `auth/`) is defined in its respective module.
+-   These routers are then wrapped by the `onRequestTrpc` adapter function (from `server/src/trpc/trpc.adapter.ts`) and exported as individual HTTPS Firebase Functions. For example, the `partiesRouter` becomes the `parties` Firebase Function.
+-   The main `appRouter` defined in `server/src/trpc/trpc.app-router.ts` consolidates all these individual routers. Its primary purpose is to generate the `AppRouter` TypeScript definition, which is shared with the client for end-to-end type safety, rather than being deployed as a single, monolithic API endpoint.
+
+### Webhook Handlers
+
+-   These are standard HTTPS Firebase Functions (using `onRequest`) designed to receive and process webhook calls from various third-party services.
+-   **Key Webhook Integrations:**
+    -   **Stripe (`stripe/functions/webhook.ts`):** Handles events like `payment_intent.succeeded` to trigger post-payment fulfillment logic (e.g., booking holiday programs).
+    -   **Acuity Scheduling (`acuity/functions/webhook.ts`):** Processes updates from Acuity, such as new appointments or cancellations, to keep the portal's data in sync.
+    -   **Paperform (`paperforms/functions/webhooks/paperform.webhook.ts`):** Ingests new form submissions from Paperform.
+    -   **Contact Form 7 (`contact-form-7/webhook/contact-form-7-webhook.ts`):** Receives submissions from Contact Form 7, likely used on an external website.
+
+### Pub/Sub Functions
+
+-   These functions are triggered by messages published to Google Cloud Pub/Sub topics, enabling asynchronous background processing.
+-   **Key Pub/Sub Tasks:**
+    -   **Party Bookings (`party-bookings/functions/pubsub/...`):** Handles tasks like sending party confirmation forms, feedback emails, guest list emails, and reminder emails.
+    -   **Paperform (`paperforms/functions/pubsub/paperform.pubsub.ts`):** Used for further processing of Paperform submissions after initial webhook ingestion (e.g., data transformation, notifications).
+
+## Key Design Patterns
+
+### Lazy Instantiation of SDK Clients
+
+-   To optimize for cold starts in the serverless Firebase Functions environment, heavy third-party SDK clients (e.g., for Stripe, Xero, Acuity) are instantiated lazily.
+-   This pattern typically involves:
+    -   Using a singleton approach for client instances (e.g., `StripeClient.getInstance()`).
+    -   Dynamically importing the SDK (`await import('some-sdk')`) only when the client is first requested.
+    -   This ensures that a function invocation doesn't pay the performance penalty of importing and parsing large SDKs unless that specific SDK is actually needed for the current operation. An example can be seen in `server/src/stripe/core/stripe-client.ts`.
+
+## Development
+
+To run the server functions locally for development, Firebase emulators are used:
+
+```bash
+npm run serve
+```
+
+This command (from `server/package.json`) typically builds the server code (including the `fizz-kidz` module) in watch mode and starts the Firebase emulators for Functions and Pub/Sub.

--- a/server/fizz-kidz/README.md
+++ b/server/fizz-kidz/README.md
@@ -1,19 +1,43 @@
-# Package Overview
+# Fizz Kidz Core Module (`fizz-kidz`)
 
-`fizz-kidz` is a package that holds shared types and utility methods to be used across Firebase and React.
+This directory contains the `fizz-kidz` module, a crucial internal library for the Fizz Kidz Portal. It encapsulates shared core business logic, type definitions, constants, and utilities used across the platform.
 
-## Types included are:
+## Table of Contents
 
-### Party Bookings
+- [Purpose](#purpose)
+- [Structure](#structure)
+- [Build and Usage](#build-and-usage)
 
-- [`Booking.Domain.Fields`](./src/booking/domain/index.ts) where `date` and `time` are separated into their own fields
-- [`Booking.Network.Fields`](./src/booking/network/index.ts) where `dateTime` is merged into a [Firestore Timestamp](https://firebase.google.com/docs/reference/js/firebase.firestore.Timestamp)
-- [`Booking.Locations`](./src/booking/locations.ts), [`Booking.Creations`](./src/booking/creations.ts), [`Booking.CreationDisplayValues`](./src/booking/creationDisplayValues.ts) and [`Booking.CakeFlavours`](./src/booking/cakeFlavours.ts)
+## Purpose
 
-### Acuity Scheduling
+The `fizz-kidz` module serves as the central hub for common functionalities and data structures:
 
-- Constants used to identify Acuity [intake forms](https://help.acuityscheduling.com/hc/en-us/articles/219149377-Client-Intake-Forms-Agreements) and fields along with [utility](./src/acuity/utilities.ts) to help access them
+-   **Shared Business Logic:** Contains reusable functions and rules related to various aspects of the Fizz Kidz operations (e.g., bookings, scheduling, invoicing).
+-   **Type Definitions:** Provides a single source of truth for TypeScript types used by both the server-side Firebase Functions and potentially by the client-side application (especially for data consistency).
+-   **Constants & Enums:** Centralizes platform-wide constants, like service locations, roles, permissions, and specific configurations for third-party services.
+-   **Utilities:** Offers helper functions for common tasks like date manipulation, string formatting, or interacting with third-party APIs in a standardized way.
 
-### Google Apps Script
+**Location within `server/`:**
+This module is located within the main `server/` directory (as `server/fizz-kidz/`) primarily due to Firebase Functions' deployment model. Firebase requires local dependencies to be packaged within the function's root directory. Placing `fizz-kidz` here ensures it's correctly included when deploying the serverless functions.
 
-- [Constants](./src/appsscript/index.ts) to identify all available methods that can be called in GAS
+## Structure
+
+The module is organized by feature or domain within its `src/` directory:
+
+-   **`src/index.ts`**: The main entry point that exports all public functionalities of the module.
+-   **`src/core/`**: Defines fundamental platform concepts like `Location`, `Role`, `AuthUser`, and `Permission`.
+-   **`src/partyBookings/`**: Contains extensive logic for party bookings, including types for `Booking`, `Addition`, `Creation`, and `Invitation` utilities.
+-   **`src/acuity/`**, **`src/stripe/`**, **`src/square/`**, **`src/zoho/`**, **`src/paperform/`**: Provide types, constants, and utility functions for interacting with these respective third-party services.
+-   **`src/after-school-program/`**, **`src/holidayPrograms/`**, **`src/events/`**: Contain logic specific to these program types.
+-   **`src/onboarding/`**, **`src/timesheets/`**: Handle logic for staff onboarding and timesheets.
+-   **`src/firebase/`**: Contains specific Firebase-related utilities used within the module.
+-   **`src/utilities/`**: A collection of general-purpose helper functions.
+
+## Build and Usage
+
+-   **Build:** The `fizz-kidz` module has its own `package.json` and build process (typically `npm run build` within `server/fizz-kidz/`). This compiles the TypeScript code into JavaScript.
+-   **Usage:**
+    -   **Server-Side:** The main `server/` application (containing Firebase Functions) lists `fizz-kidz` as a local file dependency in its `package.json` (e.g., `"fizz-kidz": "file:fizz-kidz"`). This allows server functions to import and use the compiled code from this module.
+    -   **Client-Side:** The `client/` application also references `fizz-kidz` in its `package.json` (e.g., `"fizz-kidz": "file:../server/fizz-kidz"`) and its build scripts often trigger a build of the `fizz-kidz` module. This is primarily for accessing shared types to ensure consistency between client and server, and potentially some utility functions if needed.
+
+This module is critical for maintaining consistency and reducing code duplication across the Fizz Kidz Portal.


### PR DESCRIPTION
This commit introduces individual README.md files for the following directories:
- `client/README.md`: Details the client application's structure, routing (React Router, lazy loading, dashboard/public separation), UI component strategy (shadcn/ui, phasing out MUI/AntD), state management (Zustand, React Context), and API communication (tRPC).
- `server/README.md`: Explains the server application's architecture, focusing on Firebase Functions deployment (tRPC routers as individual functions, webhooks for Stripe/Acuity/Paperform/ContactForm7, Pub/Sub functions), project structure, core technologies, and the lazy instantiation pattern for SDK clients to optimize serverless performance.
- `server/fizz-kidz/README.md`: Describes the `fizz-kidz` shared core module, its purpose (centralizing business logic, types, constants, utilities), internal structure, and how it's built and consumed by both the server and client projects.