### PR TITLE
Add fortnightly minimum shift-length Pub/Sub report and share minimum-shift logic

### DIFF
--- a/server/fizz-kidz/src/firebase/functions.ts
+++ b/server/fizz-kidz/src/firebase/functions.ts
@@ -10,6 +10,7 @@ export interface PubSubFunctions {
         | { name: 'sendPartyFeedbackEmails' }
         | { name: 'remindAboutWwcc' }
         | { name: 'remindAboutTurning18NextMonth' }
+        | { name: 'sendMinimumShiftLengthReport' }
         | { name: 'updateSlingWages' }
         | { name: 'paperformSubmission'; form: 'incursion'; data: PaperFormResponse<IncursionForm> }
         | {

--- a/server/src/pubsub.ts
+++ b/server/src/pubsub.ts
@@ -11,6 +11,7 @@ import { sendPartyForms } from './party-bookings/core/send-party-forms'
 import { updateSlingWages } from './sling/update-sling-wages'
 import { remindAboutTurning18NextMonth } from './staff/core/remind-about-turning-18-next-month'
 import { remindAboutWwcc } from './staff/core/remind-about-wwcc'
+import { sendMinimumShiftLengthReport } from './staff/core/send-minimum-shift-length-report'
 import { onMessagePublished, logError } from './utilities'
 
 export const pubsub = onMessagePublished('background', async (input: PubSubFunctions['background']) => {
@@ -51,6 +52,10 @@ export const pubsub = onMessagePublished('background', async (input: PubSubFunct
         case 'updateSlingWages':
             // 6:00am every Friday
             await updateSlingWages()
+            break
+        case 'sendMinimumShiftLengthReport':
+            // every second Tuesday at 8:30am
+            await sendMinimumShiftLengthReport()
             break
         case 'paperformSubmission':
             // triggered by paperform webhook

--- a/server/src/sendgrid/MailClient.ts
+++ b/server/src/sendgrid/MailClient.ts
@@ -489,6 +489,20 @@ export class MailClient {
                     template: 'turning_18_next_month_reminder.html',
                     useMjml: false,
                 }
+            case 'minimumShiftLengthReport':
+                return {
+                    emailInfo: {
+                        to,
+                        from: {
+                            name: 'Fizz Kidz Portal',
+                            email: 'people@fizzkidz.com.au',
+                        },
+                        subject: subject || 'Minimum shift length report',
+                        replyTo: replyTo || 'people@fizzkidz.com.au',
+                    },
+                    template: 'minimum_shift_length_report.html',
+                    useMjml: false,
+                }
             case 'createDiscountCode':
                 return {
                     emailInfo: {

--- a/server/src/sendgrid/mjml/minimum_shift_length_report.html
+++ b/server/src/sendgrid/mjml/minimum_shift_length_report.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html>
+    <head>
+        <base target="_top" />
+        <style>
+            table {
+                border-collapse: collapse;
+                width: 100%;
+                margin-bottom: 20px;
+            }
+
+            th,
+            td {
+                border: 1px solid #ddd;
+                padding: 8px;
+                text-align: left;
+            }
+
+            th {
+                background-color: #f5f5f5;
+            }
+        </style>
+    </head>
+
+    <body>
+        <p>Minimum shift length exceptions for <strong>{{periodLabel}}</strong>.</p>
+
+        {{#studios}}
+        <h3>{{studio}}</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Employee</th>
+                    <th>Position</th>
+                    <th>Shift date</th>
+                    <th>Worked</th>
+                    <th>Minimum</th>
+                    <th>Notes</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{#shifts}}
+                <tr>
+                    <td>{{employeeName}}</td>
+                    <td>{{positionName}}</td>
+                    <td>{{shiftDate}}</td>
+                    <td>{{workedLength}}</td>
+                    <td>{{minimumLength}}</td>
+                    <td>{{notes}}</td>
+                </tr>
+                {{/shifts}}
+            </tbody>
+        </table>
+        {{/studios}}
+    </body>
+</html>

--- a/server/src/sendgrid/types.ts
+++ b/server/src/sendgrid/types.ts
@@ -415,6 +415,20 @@ export type Emails = {
         month: string
         employees: string[]
     }
+    minimumShiftLengthReport: {
+        periodLabel: string
+        studios: {
+            studio: string
+            shifts: {
+                employeeName: string
+                positionName: string
+                shiftDate: string
+                workedLength: string
+                minimumLength: string
+                notes: string
+            }[]
+        }[]
+    }
 
     accountInvite: {
         firstname: string

--- a/server/src/staff/core/send-minimum-shift-length-report.ts
+++ b/server/src/staff/core/send-minimum-shift-length-report.ts
@@ -1,0 +1,50 @@
+import { capitalise, FRANCHISE_STUDIOS, type FranchiseOrMaster, type ShiftUnderMinimumShiftLength } from 'fizz-kidz'
+import { DateTime } from 'luxon'
+
+import { SlingClient } from '@/sling/sling-client'
+import { MailClient } from '@/sendgrid/MailClient'
+
+import { getShiftsUnderMinimumShiftLengthForTimesheets } from './timesheets/minimum-shift-length-report'
+import { getWeeks } from './timesheets/timesheets.utils'
+
+const XERO_STUDIOS: FranchiseOrMaster[] = ['master', ...FRANCHISE_STUDIOS]
+const TIMEZONE = 'Australia/Melbourne'
+
+export async function sendMinimumShiftLengthReport() {
+    const endDate = DateTime.now().setZone(TIMEZONE).minus({ days: 1 }).startOf('day')
+    const startDate = endDate.minus({ days: 13 }).startOf('day')
+
+    const slingClient = new SlingClient()
+    const slingUsers = await slingClient.getUsers()
+    const weeks = getWeeks(startDate, endDate)
+
+    const reportByStudio = await Promise.all(
+        XERO_STUDIOS.map(async (studio) => {
+            const shifts: ShiftUnderMinimumShiftLength[] = []
+            for (const week of weeks) {
+                const allTimesheets = await slingClient.getTimesheets(week.start.toJSDate(), week.end.toJSDate())
+                shifts.push(
+                    ...getShiftsUnderMinimumShiftLengthForTimesheets({
+                        studio,
+                        slingUsers,
+                        allTimesheets,
+                    })
+                )
+            }
+
+            return {
+                studio: studio === 'master' ? 'Head office' : capitalise(studio),
+                shifts,
+            }
+        })
+    )
+
+    const studiosWithShifts = reportByStudio.filter((it) => it.shifts.length > 0)
+    if (studiosWithShifts.length === 0) return
+
+    const mailClient = await MailClient.getInstance()
+    await mailClient.sendEmail('minimumShiftLengthReport', 'people@fizzkidz.com.au', {
+        periodLabel: `${startDate.toFormat('d LLL yyyy')} - ${endDate.toFormat('d LLL yyyy')}`,
+        studios: studiosWithShifts,
+    })
+}

--- a/server/src/staff/core/timesheets/generate-timesheets.ts
+++ b/server/src/staff/core/timesheets/generate-timesheets.ts
@@ -20,13 +20,8 @@ import { isUsingEmulator, throwTrpcError } from '@/utilities'
 import { XeroClient } from '@/xero/XeroClient'
 
 import { didTurn18DuringRange, getEmployeesWithBirthdayDuringRange } from '../staff-birthdays'
-import {
-    createTimesheetRows,
-    getShiftsUnderMinimumShiftLength,
-    getWeeks,
-    isYoungerThan18,
-    SlingLocationsMap,
-} from './timesheets.utils'
+import { getShiftsUnderMinimumShiftLengthForTimesheets } from './minimum-shift-length-report'
+import { createTimesheetRows, getWeeks, isYoungerThan18, SlingLocationsMap } from './timesheets.utils'
 
 import type { Rate } from './timesheets.types'
 import type { TimesheetRow } from './timesheets.utils'
@@ -120,6 +115,13 @@ export async function generateTimesheets({ startDateInput, endDateInput, studio 
         for (const week of weeks) {
             // get all shifts for the time period
             const allTimesheets = await slingClient.getTimesheets(week.start.toJSDate(), week.end.toJSDate())
+            shiftsUnderMinimumShiftLength.push(
+                ...getShiftsUnderMinimumShiftLengthForTimesheets({
+                    studio,
+                    slingUsers,
+                    allTimesheets,
+                })
+            )
             const timesheets = allTimesheets
                 .filter((it) => it.status === 'published')
                 .filter((it) => {
@@ -136,15 +138,6 @@ export async function generateTimesheets({ startDateInput, endDateInput, studio 
             for (const slingUser of slingUsers) {
                 const usersTimesheets = timesheets.filter((it) => it.user.id === slingUser.id)
                 if (usersTimesheets.length === 0) continue
-
-                shiftsUnderMinimumShiftLength.push(
-                    ...getShiftsUnderMinimumShiftLength({
-                        firstName: slingUser.legalName,
-                        lastName: slingUser.lastname,
-                        usersTimesheets,
-                        timezone: slingUser.timezone,
-                    })
-                )
 
                 let xeroUser = xeroUsers?.find(
                     (user) =>

--- a/server/src/staff/core/timesheets/minimum-shift-length-report.ts
+++ b/server/src/staff/core/timesheets/minimum-shift-length-report.ts
@@ -1,0 +1,45 @@
+import { isFranchise, type FranchiseOrMaster, type ShiftUnderMinimumShiftLength } from 'fizz-kidz'
+
+import type { Timesheet, User } from '@/sling/sling.types'
+
+import { getShiftsUnderMinimumShiftLength, SlingLocationsMap } from './timesheets.utils'
+
+export function getShiftsUnderMinimumShiftLengthForTimesheets({
+    studio,
+    slingUsers,
+    allTimesheets,
+}: {
+    studio: FranchiseOrMaster
+    slingUsers: User[]
+    allTimesheets: Timesheet[]
+}) {
+    const timesheets = allTimesheets
+        .filter((it) => it.status === 'published')
+        .filter((it) => {
+            // depending on the franchise, filter out the location
+            const slingLocation = SlingLocationsMap[it.location.id]
+            if (studio === 'master') {
+                if (slingLocation === 'head-office') return true
+                return !isFranchise(slingLocation)
+            }
+            return slingLocation === studio
+        })
+
+    const shiftsUnderMinimumShiftLength: ShiftUnderMinimumShiftLength[] = []
+
+    for (const slingUser of slingUsers) {
+        const usersTimesheets = timesheets.filter((it) => it.user.id === slingUser.id)
+        if (usersTimesheets.length === 0) continue
+
+        shiftsUnderMinimumShiftLength.push(
+            ...getShiftsUnderMinimumShiftLength({
+                firstName: slingUser.legalName,
+                lastName: slingUser.lastname,
+                usersTimesheets,
+                timezone: slingUser.timezone,
+            })
+        )
+    }
+
+    return shiftsUnderMinimumShiftLength
+}


### PR DESCRIPTION
### Motivation
- Provide a fortnightly Pub/Sub-driven report that emails people a table of shifts under the payroll minimum while preserving the existing payroll UI behaviour. 
- Avoid duplication by extracting the minimum-shift detection so payroll generation and the background report use the same rule set. 

### Description
- Added a reusable helper `getShiftsUnderMinimumShiftLengthForTimesheets` in `server/src/staff/core/timesheets/minimum-shift-length-report.ts` and switched `generateTimesheets` to call it so both flows share the same extraction logic. 
- Implemented a new background task `sendMinimumShiftLengthReport` in `server/src/staff/core/send-minimum-shift-length-report.ts` that scans a 14-day window across `master` + franchise studios and emails results. 
- Wired the new task into the Pub/Sub contract and dispatcher by updating `server/fizz-kidz/src/firebase/functions.ts` and `server/src/pubsub.ts`. 
- Added SendGrid support: new email payload type in `server/src/sendgrid/types.ts`, template mapping in `server/src/sendgrid/MailClient.ts`, and an HTML template `server/src/sendgrid/mjml/minimum_shift_length_report.html`. 

### Testing
- Ran formatting with `npx prettier --write <files>` which completed successfully. 
- Ran `npm run lint` in `server/` which failed with an environment/tooling ESLint import attribute error that appears unrelated to these changes. 
- Ran `npm run ts:check` in `server/` which surfaced many existing repo-wide type/build errors (missing built outputs and dev deps); these are pre-existing and not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f066ed948c8327b610d682ca8e02f7)