### PR TITLE
Run minimum shift-length report only on fortnightly pay-cycle Mondays

### DIFF
--- a/server/src/pubsub.ts
+++ b/server/src/pubsub.ts
@@ -54,7 +54,7 @@ export const pubsub = onMessagePublished('background', async (input: PubSubFunct
             await updateSlingWages()
             break
         case 'sendMinimumShiftLengthReport':
-            // every second Monday at 6:00am
+            // every Monday at 6:00am; the report checks whether it's the fortnightly pay-cycle Monday
             await sendMinimumShiftLengthReport()
             break
         case 'paperformSubmission':

--- a/server/src/staff/core/send-minimum-shift-length-report.ts
+++ b/server/src/staff/core/send-minimum-shift-length-report.ts
@@ -17,6 +17,9 @@ import { getWeeks } from './timesheets/timesheets.utils'
 
 const XERO_STUDIOS: FranchiseOrMaster[] = ['master', ...FRANCHISE_STUDIOS]
 const TIMEZONE = 'Australia/Melbourne'
+// Google Cloud Scheduler cannot run "every second Monday", so we trigger this job every Monday and
+// enforce the fortnightly cadence in code from this anchor date.
+const FIRST_FORTNIGHTLY_REPORT_DATE = DateTime.fromISO('2026-05-04', { zone: TIMEZONE }).startOf('day')
 
 export async function sendMinimumShiftLengthReport({
     startDate: customStartDate,
@@ -25,6 +28,17 @@ export async function sendMinimumShiftLengthReport({
     startDate?: Date
     endDate?: Date
 } = {}) {
+    // Keep manual/scripted runs (with explicit dates) available at any time.
+    // For scheduled runs without explicit dates, only continue on the fortnightly Monday pay cycle.
+    if (!customStartDate && !customEndDate) {
+        const reportDate = DateTime.now().setZone(TIMEZONE).startOf('day')
+        const daysSinceFirstReport = Math.trunc(reportDate.diff(FIRST_FORTNIGHTLY_REPORT_DATE, 'days').days)
+        const isMonday = reportDate.weekday === 1
+        const isFortnightlyMonday = daysSinceFirstReport >= 0 && daysSinceFirstReport % 14 === 0
+
+        if (!isMonday || !isFortnightlyMonday) return
+    }
+
     const endDate = customEndDate
         ? DateTime.fromJSDate(customEndDate).setZone(TIMEZONE).startOf('day')
         : DateTime.now().setZone(TIMEZONE).minus({ days: 1 }).startOf('day')


### PR DESCRIPTION
### Motivation
- Google Cloud Scheduler cannot express "every second Monday", so the job is scheduled weekly and must enforce the fortnightly cadence in code.  
- Manual or scripted runs with explicit `startDate`/`endDate` must still be allowed at any time.

### Description
- Added an anchor `FIRST_FORTNIGHTLY_REPORT_DATE` and timezone handling in `server/src/staff/core/send-minimum-shift-length-report.ts` to calculate the fortnightly cadence.  
- For scheduled runs without `startDate`/`endDate`, the function now checks that today is Monday and that it falls on the fortnightly cycle relative to the anchor, returning early otherwise.  
- Updated `server/src/pubsub.ts` comment for the `sendMinimumShiftLengthReport` task to reflect that the job is triggered weekly and the code enforces the fortnightly schedule.

### Testing
- Ran the TypeScript build with `npm run build`, which completed successfully.  
- Executed the existing automated test suite with `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d642a4088327b876cf62f9c59306)